### PR TITLE
Fix: #16 Adding missing example compose file and implementing extension from the base one

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Or you can run an entire example system (including both CMDR
 services and an example business logic service) via docker-compose:
 
 ``` sh
-$ docker-compose -f docker-compose-example.yml up --build
+$ docker-compose -f docker-compose.yml -f docker-compose-example.yml up
 ```
 
 #### Running Locally

--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -1,0 +1,22 @@
+# Copyright 2016 Capital One Services, LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+version: '2'
+services:
+  cmdr:
+    build: .
+    ports: 
+      - "3000:3000"
+    depends_on:
+      - "database"
+      - "kafka"
+      - "zookeeper"


### PR DESCRIPTION
FIx for https://github.com/capitalone/cqrs-manager-for-distributed-reactive-services/issues/16